### PR TITLE
feat/signin - 로그인 기능

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -7,3 +7,12 @@ Content-Type: application/json
   "password": "Pass1234!",
   "nickname": "mentos"
 }
+
+### 로그인
+POST localhost:8080/signin
+Content-Type: application/json
+
+{
+  "username": "jinho",
+  "password": "Pass1234!"
+}

--- a/src/main/java/com/griotold/backend_onboarding/application/dto/UserSignin.java
+++ b/src/main/java/com/griotold/backend_onboarding/application/dto/UserSignin.java
@@ -1,0 +1,7 @@
+package com.griotold.backend_onboarding.application.dto;
+
+public record UserSignin(
+        String username,
+        String password
+) {
+}

--- a/src/main/java/com/griotold/backend_onboarding/application/exception/ErrorCode.java
+++ b/src/main/java/com/griotold/backend_onboarding/application/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 유저 정보가 존재하지 않습니다."),
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "유저 이름이 이미 존재합니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "사용자 인증에 실패했습니다."),
 
     ;
 

--- a/src/main/java/com/griotold/backend_onboarding/application/interfaces/TokenProvider.java
+++ b/src/main/java/com/griotold/backend_onboarding/application/interfaces/TokenProvider.java
@@ -1,0 +1,7 @@
+package com.griotold.backend_onboarding.application.interfaces;
+
+import com.griotold.backend_onboarding.domain.Role;
+
+public interface TokenProvider {
+    String createAccessToken(Long userId, Role role);
+}

--- a/src/main/java/com/griotold/backend_onboarding/infra/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/griotold/backend_onboarding/infra/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,44 @@
+package com.griotold.backend_onboarding.infra.config.jwt;
+
+import com.griotold.backend_onboarding.application.interfaces.TokenProvider;
+import com.griotold.backend_onboarding.domain.Role;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider implements TokenProvider {
+
+    @Value("${spring.application.name}")
+    private String issuer;
+
+    @Value("${service.jwt.access-expiration}")
+    private Long accessExpiration;
+
+    private final SecretKey secretKey;
+
+    public JwtTokenProvider(@Value("${service.jwt.secret-key}") String secretKey) {
+        this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey));
+    }
+
+    @Override
+    public String createAccessToken(Long userId, Role role) {
+        return Jwts.builder()
+                .claim("user_id", userId)
+                .claim("role", role.name())
+                .issuer(issuer)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + accessExpiration))
+                .signWith(secretKey, io.jsonwebtoken.SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    SecretKey getSecretKey() {
+        return secretKey;
+    }
+}

--- a/src/main/java/com/griotold/backend_onboarding/infra/config/security/AuthConfig.java
+++ b/src/main/java/com/griotold/backend_onboarding/infra/config/security/AuthConfig.java
@@ -33,6 +33,7 @@ public class AuthConfig {
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .authorizeRequests(authorize -> authorize
                                 .requestMatchers("/signup").permitAll()
+                                .requestMatchers("/signin").permitAll()
                                 .requestMatchers("/h2-console/**").permitAll()
                                 .anyRequest().authenticated()
                 )
@@ -43,7 +44,6 @@ public class AuthConfig {
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler));
 
-        // 설정된 보안 필터 체인을 반환합니다.
         return http.build();
     }
 }

--- a/src/main/java/com/griotold/backend_onboarding/presentation/controller/AuthController.java
+++ b/src/main/java/com/griotold/backend_onboarding/presentation/controller/AuthController.java
@@ -1,7 +1,10 @@
-package com.griotold.backend_onboarding.presentation;
+package com.griotold.backend_onboarding.presentation.controller;
 
 import com.griotold.backend_onboarding.application.dto.UserSignupResponse;
 import com.griotold.backend_onboarding.application.service.AuthService;
+import com.griotold.backend_onboarding.presentation.dto.ApiResponse;
+import com.griotold.backend_onboarding.presentation.dto.UserSigninRequest;
+import com.griotold.backend_onboarding.presentation.dto.UserSignupRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,5 +23,11 @@ public class AuthController {
     public ApiResponse<UserSignupResponse> signup(@RequestBody @Valid UserSignupRequest request) {
         log.info("signUp.UserSignUpRequest: {}", request);
         return ApiResponse.success(authService.signup(request.toServiceDto()));
+    }
+
+    @PostMapping("/signin")
+    public ApiResponse<String> signin(@RequestBody @Valid UserSigninRequest request) {
+        log.info("signIn.UserSigninRequest: {}", request);
+        return ApiResponse.success(authService.signin(request.toServiceDto()));
     }
 }

--- a/src/main/java/com/griotold/backend_onboarding/presentation/dto/ApiResponse.java
+++ b/src/main/java/com/griotold/backend_onboarding/presentation/dto/ApiResponse.java
@@ -1,8 +1,8 @@
-package com.griotold.backend_onboarding.presentation;
+package com.griotold.backend_onboarding.presentation.dto;
 
 public record ApiResponse<T>(
         String message,
-        T date
+        T data
 ) {
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>("API 요청에 성공했습니다", data);

--- a/src/main/java/com/griotold/backend_onboarding/presentation/dto/UserSigninRequest.java
+++ b/src/main/java/com/griotold/backend_onboarding/presentation/dto/UserSigninRequest.java
@@ -1,0 +1,17 @@
+package com.griotold.backend_onboarding.presentation.dto;
+
+import com.griotold.backend_onboarding.application.dto.UserSignin;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserSigninRequest(
+        @NotBlank
+        String username,
+
+        @NotBlank
+        String password
+) {
+
+    public UserSignin toServiceDto() {
+        return new UserSignin(username, password);
+    }
+}

--- a/src/main/java/com/griotold/backend_onboarding/presentation/dto/UserSignupRequest.java
+++ b/src/main/java/com/griotold/backend_onboarding/presentation/dto/UserSignupRequest.java
@@ -1,4 +1,4 @@
-package com.griotold.backend_onboarding.presentation;
+package com.griotold.backend_onboarding.presentation.dto;
 
 import com.griotold.backend_onboarding.application.dto.UserSignup;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,4 +26,4 @@ spring:
 service:
   jwt:
     secret-key: ${SECRET_KEY}
-    access-expiration: 3600000 #1시간
+    access-expiration: 3600000 # 1시간

--- a/src/test/java/com/griotold/backend_onboarding/BackendOnboardingApplicationTests.java
+++ b/src/test/java/com/griotold/backend_onboarding/BackendOnboardingApplicationTests.java
@@ -2,7 +2,9 @@ package com.griotold.backend_onboarding;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class BackendOnboardingApplicationTests {
 

--- a/src/test/java/com/griotold/backend_onboarding/application/service/AuthServiceTest.java
+++ b/src/test/java/com/griotold/backend_onboarding/application/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.griotold.backend_onboarding.application.service;
 
+import com.griotold.backend_onboarding.application.dto.UserSignin;
 import com.griotold.backend_onboarding.application.dto.UserSignup;
 import com.griotold.backend_onboarding.application.dto.UserSignupResponse;
 import com.griotold.backend_onboarding.application.exception.AuthException;
@@ -11,10 +12,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ActiveProfiles("test")
 @Transactional
@@ -27,8 +30,11 @@ class AuthServiceTest {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     @Test
-    @DisplayName("회원가입 성공")
+    @DisplayName("signup - 회원가입 성공")
     void signup_success() {
         // given
         UserSignup signup = new UserSignup("testUser", "pass1234", "mentos");
@@ -49,7 +55,7 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("회원가입 실패 - 중복된 username")
+    @DisplayName("signup - 중복된 username")
     void signup_whenUsernameIsDuplicated() {
         // given
         userRepository.save(User.create("testUser", "pass1234", "mentos"));
@@ -62,4 +68,53 @@ class AuthServiceTest {
 
     }
 
+    @Test
+    @DisplayName("signin - 로그인 성공")
+    void signin_success() {
+        // given
+        String username = "jinho";
+        String password = "Pass1234!";
+        String nickname = "mentos";
+
+        User user = User.create(username, passwordEncoder.encode(password), nickname);
+        userRepository.save(user);
+
+        // when
+        String token = authService.signin(new UserSignin(username, password));
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(token).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("signin - 존재하지 않는 사용자")
+    void signin_whenUserNotFound() {
+        // given
+        String username = "nonexistent";
+        String password = "Pass1234!";
+
+        // when & then
+        assertThatThrownBy(() -> authService.signin(new UserSignin(username, password)))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("signin - 잘못된 비밀번호")
+    void signin_whenInvalidPassword() {
+        // given
+        String username = "jinho";
+        String password = "Pass1234!";
+        String wrongPassword = "WrongPass1234!";
+        String nickname = "mentos";
+
+        User user = User.create(username, password, nickname);
+        userRepository.save(user);
+
+        // when & then
+        assertThatThrownBy(() -> authService.signin(new UserSignin(username, wrongPassword)))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
+    }
 }

--- a/src/test/java/com/griotold/backend_onboarding/infra/config/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/griotold/backend_onboarding/infra/config/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,57 @@
+package com.griotold.backend_onboarding.infra.config.jwt;
+
+import com.griotold.backend_onboarding.domain.Role;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.crypto.SecretKey;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtTokenProviderTest {
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        SecretKey secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS512);
+        String encodedKey = Encoders.BASE64URL.encode(secretKey.getEncoded());
+        jwtTokenProvider = new JwtTokenProvider(encodedKey);
+        ReflectionTestUtils.setField(jwtTokenProvider, "issuer", "auth-service");
+        ReflectionTestUtils.setField(jwtTokenProvider, "accessExpiration", 3600000L);
+    }
+
+    @Test
+    @DisplayName("JWT 토큰 생성 테스트")
+    void createAccessTokenTest() {
+        // given
+        Long userId = 1L;
+        Role role = Role.USER;
+
+        // when
+        String token = jwtTokenProvider.createAccessToken(userId, role);
+
+        // then
+        assertThat(token).isNotNull();
+
+        Claims claims = Jwts.parser()
+                .verifyWith(jwtTokenProvider.getSecretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        assertThat(claims.get("user_id", Long.class)).isEqualTo(userId);
+        assertThat(claims.get("role")).isEqualTo(role.name());
+        assertThat(claims.getIssuer()).isEqualTo("auth-service");
+    }
+}

--- a/src/test/java/com/griotold/backend_onboarding/presentation/AuthControllerTest.java
+++ b/src/test/java/com/griotold/backend_onboarding/presentation/AuthControllerTest.java
@@ -5,6 +5,9 @@ import com.griotold.backend_onboarding.application.service.AuthService;
 import com.griotold.backend_onboarding.infra.config.security.AuthConfig;
 import com.griotold.backend_onboarding.infra.config.security.CustomAccessDeniedHandler;
 import com.griotold.backend_onboarding.infra.config.security.CustomAuthenticationEntryPoint;
+import com.griotold.backend_onboarding.presentation.controller.AuthController;
+import com.griotold.backend_onboarding.presentation.dto.UserSigninRequest;
+import com.griotold.backend_onboarding.presentation.dto.UserSignupRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -204,5 +207,54 @@ class AuthControllerTest {
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
+
+    @DisplayName("signin - 성공")
+    @Test
+    void signin_success() throws Exception {
+        // given
+        String username = "testuser";
+        String password = "Pass1234!";
+        UserSigninRequest userSigninRequest = new UserSigninRequest(username, password);
+
+        // when & then
+        mockMvc.perform(post("/signin")
+                        .content(objectMapper.writeValueAsString(userSigninRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("signin - username이 없을 때")
+    @Test
+    void signin_whenUsernameIsNull() throws Exception {
+        // given
+        String username = null;
+        String password = "Pass1234!";
+        UserSigninRequest userSigninRequest = new UserSigninRequest(username, password);
+
+        // when & then
+        mockMvc.perform(post("/signin")
+                        .content(objectMapper.writeValueAsString(userSigninRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("signin - password가 없을 때")
+    @Test
+    void signin_whenPasswordIsNull() throws Exception {
+        // given
+        String username = "testuser";
+        String password = null;
+        UserSigninRequest userSigninRequest = new UserSigninRequest(username, password);
+
+        // when & then
+        mockMvc.perform(post("/signin")
+                        .content(objectMapper.writeValueAsString(userSigninRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
 
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -25,7 +25,7 @@ spring:
 service:
   jwt:
     access-expiration: 3600000
-    secret-key: "testkey"
+    secret-key: "401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b3727429080fb337591abd3e44453b954555b7a0812e1081c39b740293f765eae731f5a65ed1"
 
 sql:
   init:


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/signin -> dev
### 이슈
- #3 
### Description
- 로그인 기능을 구현했습니다.
- 로그인 성공
![로그인성공](https://github.com/user-attachments/assets/963dc24e-14c0-41f6-a1e8-aa9783302f67)

- 로그인 실패 - 없는 이름
![로그인실패_없는이름](https://github.com/user-attachments/assets/3132440a-a2c7-40e0-a2bc-d2a8be412929)

- 로그인 실패 - 잘못된 비밀번호
![로그인실패_잘못된패스워드](https://github.com/user-attachments/assets/c788ec74-4086-44ab-8ef7-3d1b7a55c0bd)

### To Reviewers
- 로그인 기능 구현
- 예외 처리
- 테스트 코드 작성